### PR TITLE
Fixed build as libtensorflow_framework is now part of libtensorflow p…

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0301-TF-Text-to-use-its-own-protobuf.patch       #[protobuf == "3.11.2"]
 
 build:
-  number: 1
+  number: 2
   string: h{{ PKG_HASH }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}
   ignore_run_exports:
     - libgcc-ng
@@ -32,6 +32,7 @@ requirements:
     - python {{ python }}
     - numpy {{ numpy }}
     - tensorflow-base {{ tensorflow }}
+    - libtensorflow {{ tensorflow }}
     - typing_extensions {{ typing_extensions }}     # [py<38]
     - python-flatbuffers {{ flatbuffers }}
     # Use pins to control cos6/cos7 match
@@ -41,6 +42,7 @@ requirements:
     - python {{ python }}
     - numpy {{ numpy }}
     - tensorflow-base {{ tensorflow }}
+    - libtensorflow {{ tensorflow }}
     - tensorflow-hub {{ tensorflow_hub }}
     - typing_extensions {{ typing_extensions }}     # [py<38]
     # Use pins to control cos6/cos7 match


### PR DESCRIPTION
…ackage

## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

TF text needs libtensorflow_framework.so at build time and runtime. Under this PR open-ce/tensorflow-feedstock#44, I moved libtensorflow_framework.so into libtensorflow package and hence I'd to add libtensorflow in the dependencies of TF Text.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
